### PR TITLE
Add the ablity to produces variant builds

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,35 @@
+const StyleDictionaryPackage = require('style-dictionary');
+const fs = require('fs');
+const deepDiff = require('return-deep-diff');
+
+const config = JSON.parse(fs.readFileSync('./config.json')); 
+
+console.log('Build started...');
+
+const StyleDictionary = require('style-dictionary').extend(config);
+StyleDictionary.buildAllPlatforms();
+
+const varitationTypes = fs.readdirSync('./variations');
+
+const base = StyleDictionary.exportPlatform('web/json');
+const output = {
+    base,
+}
+
+varitationTypes.map(function (variationType) {
+    console.log('\n==============================================');
+    output[variationType] = {};
+    fs.readdirSync(`./variations/${variationType}`).map(function (variation) {
+        console.log('\n==============================================');
+        console.log('Collision from here are normal');
+        const myConfig = Object.assign({}, config);
+        myConfig.source.push(`variations/${variationType}/${variation}/**/*.json`)
+        const StyleDictionaryVariation = require('style-dictionary').extend(config);
+        output[variationType][variation] = deepDiff(base, StyleDictionaryVariation.exportPlatform('web/json'), true);
+        
+    });
+})
+
+console.log('\n==============================================');
+console.log('Writing tokens with variations');
+fs.writeFileSync('./build/web/tokensWithVariations.json', JSON.stringify(output));

--- a/config.json
+++ b/config.json
@@ -20,6 +20,16 @@
         "format": "android/colors"
       }]
     },
+    "web/json": {
+      "transformGroup": "web",
+      "buildPath": "build/web/",
+      "files": [
+          {
+              "destination": "tokens.json",
+              "format": "json/flat"
+          }
+      ]
+    },
     "ios": {
       "transformGroup": "ios",
       "buildPath": "build/ios/",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "author": "Mike Tamis <mike.tamis@spark.co.nz>",
   "license": "",
   "scripts": {
-    "build": "style-dictionary build"
+    "build": "node build.js"
   },
   "devDependencies": {
     "style-dictionary": "^2.7.0"
+  },
+  "dependencies": {
+    "return-deep-diff": "^0.3.0"
   }
 }

--- a/variations/brands/brand1/brand1.json
+++ b/variations/brands/brand1/brand1.json
@@ -1,0 +1,17 @@
+{
+    "color": {
+      "base": {
+        "primary": {
+          "base": { "value": "#FB3640" },
+          "light": { "value": "#FC6C74" },
+          "dark": { "value": "#A02329" }
+        },
+        "secondary":  {
+          "base": { "value": "#849BB8" },
+          "light": { "value": "#1F487E" },
+          "dark": { "value": "#1D3461" }
+        }
+      }
+    }
+  }
+  

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,11 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
+return-deep-diff@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/return-deep-diff/-/return-deep-diff-0.3.0.tgz#674693fa9bade51fc4cde4bcbf8c196ee916ffe8"
+  integrity sha512-wGy41lh8lngHo+0ZK2qovjf+UciIjAYK7gPXRdHwcvQFjIdCJNuLfN+zFfs5uqZXiW4lKmVAsuLIvJgjLVjTMw==
+
 style-dictionary@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-2.7.0.tgz#9576257a6829a8c7481a661a70bb8c81d2307599"


### PR DESCRIPTION
Added the ability to have variants of a design system
this will go through the variations folder following this pattern
/{variationType}/{variation}/*.json

the point is to output a file  /dist/web/tokensWithVariations.json
which will have a base token definition, but then will also have the variations that can be deep merged on top of the base to create the variant, this is to enable the smallest single payload that has all the variants in it.

This is to be used upstream by SET-Tokens,
The variants are our different colour pairs:
'purple-orange' - our primary colour is purple our secondary being orange,
etc
